### PR TITLE
Disallow digit as a first char of * match

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ be used as column value.
 Configuration file can also have [regexp replaces](https://pkg.go.dev/regexp#Regexp.ReplaceAllString) as a map of 
 regular expression as keys and replace patterns as values.
 
-It is also possible to use simplified syntax with `*`, where `*` means key segment between two dots.
+It is also possible to use simplified syntax with `*`, where `*` means key segment (can not start with a digit) between two dots.
 
 ```json
 {

--- a/flatjsonl/config_test.go
+++ b/flatjsonl/config_test.go
@@ -2,10 +2,11 @@ package flatjsonl_test
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRegex(t *testing.T) {

--- a/flatjsonl/config_test.go
+++ b/flatjsonl/config_test.go
@@ -1,0 +1,22 @@
+package flatjsonl_test
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"regexp"
+	"testing"
+)
+
+func TestRegex(t *testing.T) {
+	s := ".context.request.Form.1674172237565.[0]"
+
+	var rs string
+	err := json.Unmarshal([]byte(`"^\\.context\\.request\\.Form\\.([^\\d][^.]+)\\.([^.]+)$"`), &rs)
+	require.NoError(t, err)
+
+	r, err := regexp.Compile(rs)
+	require.NoError(t, err)
+
+	assert.False(t, r.MatchString(s))
+}

--- a/flatjsonl/processor.go
+++ b/flatjsonl/processor.go
@@ -101,7 +101,7 @@ func NewProcessor(f Flags, cfg Config, inputs ...Input) *Processor { //nolint: f
 		"]", "\\]",
 		"{", "\\{",
 		"}", "\\}",
-		"*", "([^.]+)",
+		"*", "([^\\d][^.]+)",
 	)
 
 	for _, reg := range p.cfg.IncludeKeysRegex {


### PR DESCRIPTION
In order to mitigate unbounded growth of keys for scalar numbers.