### PR TITLE
Slow path in get single key with -extract-strings

### DIFF
--- a/flatjsonl/reader.go
+++ b/flatjsonl/reader.go
@@ -210,7 +210,7 @@ func (rd *Reader) Read(sess *readSession) error {
 		doLineErr error
 	)
 
-	if len(rd.Processor.includeKeys) == 1 {
+	if len(rd.Processor.includeKeys) == 1 && !rd.Processor.f.ExtractStrings {
 		for _, i := range rd.Processor.includeKeys {
 			kk := rd.Processor.keys[i]
 			path := make([]string, 0, len(kk.path))


### PR DESCRIPTION
When a single key is included, and this key refers to an extracted string, it would never be found during flattening, since `GetKey` does not follow value extraction.

This PR disables `GetKey` mode when `-extract-strings` is present.